### PR TITLE
rename generated folder

### DIFF
--- a/packages/svg-sass-generator/ts/partials-common/utils.ts
+++ b/packages/svg-sass-generator/ts/partials-common/utils.ts
@@ -53,4 +53,4 @@ export function getSvgString(iconPath: string) {
 export const DIR_PATH_REGEX =
   /^(?:\.{0,2}\/)?(?:[a-zA-Z0-9_-]+\/)*[a-zA-Z0-9_-]+\/?$/;
 
-export const OUTPUT_GENERATED = ".generated";
+export const OUTPUT_GENERATED = "_generated";


### PR DESCRIPTION
### Changes in this PR:
- rename to avoid netlify ignoring the folder. The prefix is to avoid collisions