### PR TITLE
[mercury] ignore showcase icons folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+packages/mercury/showcase/icons/index.html

--- a/packages/mercury/.gitignore
+++ b/packages/mercury/.gitignore
@@ -3,4 +3,5 @@
 /trash
 #showcase ignored folders (are generated on build)
 /showcase/assets/fonts/
+/showcase/assets/icons/
 /showcase/css/


### PR DESCRIPTION
### Changes in this PR:
Ignore showcase/assets/icons/ folder, since this folder is created on build