### PR TITLE
[mecury] remove tree-view `item__action` ::after

### DIFF
--- a/packages/mercury/src/components/tree-view/_tree-view-styles.scss
+++ b/packages/mercury/src/components/tree-view/_tree-view-styles.scss
@@ -216,9 +216,6 @@
   // - - - - - - - - - - - - - - - - - - - -
   #{$item__action-selector} {
     @extend %tree-view-item__action;
-    &::after {
-      background-image: var(--icon-path);
-    }
   }
 
   // - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
### Changes in this PR
- tree-view `item__action` ::after was removed because it is not required