### PR TITLE
`[svg-sass-generator]` freeze every obejct

### DIFF
--- a/packages/svg-sass-generator/ts/processor-object.ts
+++ b/packages/svg-sass-generator/ts/processor-object.ts
@@ -87,7 +87,12 @@ export const generateIconsObject = (
   icons: ${prettyIconsObject}
 };`;
 
-  writeFile(normalizedIconsObjectFilePath, output);
+  // Freeze all objects
+  const freezedObjectsOuput = output
+    .replace(/{/g, "Object.freeze({")
+    .replace(/}/g, "})");
+
+  writeFile(normalizedIconsObjectFilePath, freezedObjectsOuput);
 };
 
 /**


### PR DESCRIPTION
### Changes in this PR

- All objects in the generated object.js are freezed with `Object.freeze()` now.