### PR TITLE
[svg-sass-generator] split custom properties and placeholder selectors

### DIFF
--- a/packages/svg-sass-generator/package.json
+++ b/packages/svg-sass-generator/package.json
@@ -20,7 +20,7 @@
     "copy-to-bin": "fse copy --all --keepExisting --errorOnExist --dereference --preserveTimestamps --quiet ./js ./bin",
     "watch": "tsc --watch",
     "svg": "node ./js/processor-svg.js --srcDir=source-sample/ --outDir=dist/_generated/ --configFilePath=source-sample/my-color-states.json --showcaseDir=showcase/ --showcaseBaseHref=../dist/_generated/ --logDir=log/ --objectFilePath=object/ICONS_ASSETS.js",
-    "sass": "node ./js/processor-sass.js --srcDir=dist/ --outDir=sass/_generated/ --configFilePath=source-sample/my-color-states.json --iconsPrefix=ibm",
+    "sass": "node ./js/processor-sass.js --srcDir=dist/ --outDir=sass/_generated/ --configFilePath=source-sample/my-color-states.json --vendorAlias=ibm",
     "validate.ci": "npm run build",
     "test-mixin": "sass ./tests/tests.scss ./tests/tests.css"
   },

--- a/packages/svg-sass-generator/ts/processor-sass.ts
+++ b/packages/svg-sass-generator/ts/processor-sass.ts
@@ -25,12 +25,12 @@ const args = minimist(process.argv.slice(2));
 const SRC_PATH = await args.srcDir;
 const OUTPUT_PATH = await args.outDir;
 const COLOR_STATES_PATH = await args.configFilePath;
-const ICONS_PREFIX = await args.iconsPrefix;
+const VENDOR_ALIAS = await args.vendorAlias;
 const ALL_LISTS_FILENAME = "categories-lists.scss";
 const CATEGORIES_IMPORTS_FILENAME = "categories-imports.scss";
 const MIXINS_FILENAME = "svg-sass-mixins.scss";
 
-const ICON_PREFIX = ICONS_PREFIX ? `--icon-${ICONS_PREFIX}` : `--icon`;
+const ICON_PREFIX = VENDOR_ALIAS ? `--icon-${VENDOR_ALIAS}` : `--icon`;
 
 // Start fresh (delete current output directory)
 deleteDirectory(OUTPUT_PATH);


### PR DESCRIPTION
### Changes in this PR:

**Split files**
- Now `sass` command generates icons "css variables" and "placeholders selectors" in two separate files:
- `icons-category__variables.scss`
- `icons-category__placeholders.scss`

**Css variables prefix**
Now there is an optional argument `--vendorAlias` that can be passed to the `sass` script, that is used to prefix the icons css variables. 

For example: 
if no `--vendorAlias` argument is passed, the result will something like: `--icon__objects-one_path-one--disabled`
if `--vendorAlias` argument is passed (for example _ibm_) the result will be something like: `--icon-bpm__objects-one_path-one--disabled`
