### PR TITLE
`[mercury]`downgrade chameleon controls library version for the showcase

### DIFF
--- a/packages/mercury/showcase/assets/scripts/scripts-header.js
+++ b/packages/mercury/showcase/assets/scripts/scripts-header.js
@@ -1,8 +1,8 @@
 import { BUTTON_ICONS } from "./icons-showcase-paths.js";
 // All definitions in this script are used for local testing purposes
 // only. The IDE Web's SDK implements all this and more
-import { defineCustomElements } from "https://unpkg.com/@genexus/chameleon-controls-library@6.0.0-next.23/dist/esm/loader.js";
-import { registryProperty } from "https://unpkg.com/@genexus/chameleon-controls-library@6.0.0-next.23/dist/esm/index.js";
+import { defineCustomElements } from "https://unpkg.com/@genexus/chameleon-controls-library@6.0.0-next.21/dist/esm/loader.js";
+import { registryProperty } from "https://unpkg.com/@genexus/chameleon-controls-library@6.0.0-next.21/dist/esm/index.js";
 import { getImagePathCallbackDefinitions } from "./assets-manager.js";
 
 // Register getImagePath callbacks


### PR DESCRIPTION
### Changes in this PR:

- Downgrade chameleon controls library to 6.0.0-next.21