### PR TITLE
`[mercury]` add `$icon-classes` to the "layout" bundle

### DIFF
--- a/packages/mercury/src/bundles/scss/base/icons.scss
+++ b/packages/mercury/src/bundles/scss/base/icons.scss
@@ -1,4 +1,8 @@
 @import "config";
 @import "../../../mercury.scss";
 
-@include mercury-only($icons-path: $icons-path, $icons-variables: true);
+@include mercury-only(
+  $icons-path: $icons-path,
+  $icons-variables: true,
+  $icon-classes: true
+);


### PR DESCRIPTION
### Changes in this PR:

- icon mixins/classes have been added to the bundles, under `layout`