### PR TITLE
`[svg-sass-generator]` add `--defaultColorType` optional parameter

### DIFF
--- a/packages/svg-sass-generator/package.json
+++ b/packages/svg-sass-generator/package.json
@@ -19,7 +19,7 @@
     "copy-schema-multicolor": "fse copy ./ts/partials-svg/schema-multicolor.json ./js/partials-svg/schema-multicolor.json",
     "copy-to-bin": "fse copy --all --keepExisting --errorOnExist --dereference --preserveTimestamps --quiet ./js ./bin",
     "watch": "tsc --watch",
-    "svg": "node ./js/processor-svg.js --srcDir=source-sample/ --outDir=_generated/ --configFilePath=source-sample/my-color-states.json --showcaseDir=showcase/ --showcaseBaseHref=../_generated/ --logDir=log/ --objectFilePath=object/ICONS_ASSETS.ts",
+    "svg": "node ./js/processor-svg.js --srcDir=source-sample/ --outDir=_generated/ --configFilePath=source-sample/my-color-states.json --showcaseDir=showcase/ --showcaseBaseHref=../_generated/ --logDir=log/ --objectFilePath=object/ICONS_ASSETS.ts --defaultColorType=on-surface",
     "sass": "node ./js/processor-sass.js --srcDir=_generated/ --outDir=sass/_generated/ --configFilePath=source-sample/my-color-states.json --vendorAlias=ibm",
     "validate.ci": "npm run build",
     "test-mixin": "sass ./tests/tests.scss ./tests/tests.css"

--- a/packages/svg-sass-generator/ts/processor-object.ts
+++ b/packages/svg-sass-generator/ts/processor-object.ts
@@ -30,7 +30,8 @@ export const generateIconsObject = (
   iconsObjectFilePath: string,
   iconsColorsSchema: IconsColorsSchema,
   monochromeColorsMap: MonochromeColorsMap,
-  monochromeCategoriesMap: MonochromeCategoriesMap
+  monochromeCategoriesMap: MonochromeCategoriesMap,
+  defaultColorType: string
 ): boolean => {
   if (!sourceIconsArray || !iconsObjectFilePath) {
     return false;
@@ -93,14 +94,23 @@ export const generateIconsObject = (
     }
   });
 
+  const generateConfig = (defaultColorType: string): Config => {
+    return { defaultColorType: defaultColorType };
+  };
+
   const normalizedIconsObjectFilePath = normalizeFilePath(iconsObjectFilePath);
   const objectName = getFileNameFromPath(normalizedIconsObjectFilePath);
   const prettyIconsObject = stringifyObject(iconsObject, {
     indent: "  ",
     singleQuotes: false,
   });
+  const config = stringifyObject(generateConfig(defaultColorType), {
+    indent: "  ",
+    singleQuotes: false,
+  });
 
   const output = `export const ${objectName} = {
+  config: ${config},
   icons: ${prettyIconsObject}
 };`;
 
@@ -208,3 +218,7 @@ interface IconsObject {
 type Icon = {
   name: string;
 };
+
+interface Config {
+  defaultColorType?: string;
+}

--- a/packages/svg-sass-generator/ts/processor-svg.ts
+++ b/packages/svg-sass-generator/ts/processor-svg.ts
@@ -37,6 +37,7 @@ const SHOWCASE_PATH = await args.showcaseDir;
 const SHOWCASE_BASE_HREF = await args.showcaseBaseHref;
 const LOG_PATH = await args.logDir;
 const ICONS_OBJECT_NAME = await args.objectFilePath;
+const DEFAULT_COLOR_TYPE = await args.defaultColorType; // optional default color for monochrome icons
 
 // Optional Base URL for the showcase
 const showcaseBaseUrl = path.relative(SHOWCASE_PATH, OUTPUT_PATH) + path.sep;
@@ -83,6 +84,7 @@ if (readyObj.ready) {
         monochromeCategoriesMap,
         SHOWCASE_BASE_HREF || showcaseBaseUrl
       );
+
       // 4. Generate icons object
       if (ICONS_OBJECT_NAME) {
         generateIconsObject(
@@ -90,7 +92,8 @@ if (readyObj.ready) {
           ICONS_OBJECT_NAME,
           readyObj.statesJson,
           monochromeColorsMap,
-          monochromeCategoriesMap
+          monochromeCategoriesMap,
+          DEFAULT_COLOR_TYPE
         );
       }
     })


### PR DESCRIPTION
### Changes in this PR:

The optional `--defaultColorType` parameter is passed to the `svg` script, and it defines which is the default color for the monochrome icons.