### PR TITLE
`[mercury]` Add `getBundles` utility

### DIFF
--- a/packages/mercury/src/assets-manager.ts
+++ b/packages/mercury/src/assets-manager.ts
@@ -21,7 +21,7 @@ export {
   MercuryBundles
 } from "./bundles.js";
 
-export { getThemeBundles } from "./bundles.js";
+export { getThemeBundles, getBundles } from "./bundles.js";
 
 const ASSETS_BY_VENDOR: { [key in string]: Assets } = {};
 const ALIAS_TO_VENDOR_NAME: { [key in string]: string } = {};

--- a/packages/mercury/src/bundles.ts
+++ b/packages/mercury/src/bundles.ts
@@ -131,3 +131,39 @@ export const getThemeBundles = (basePath: string) =>
     getThemeModelItem(basePath, "utils/typography"),
     getThemeModelItem(basePath, "chameleon/scrollbar")
   ] as const satisfies ThemeModel;
+
+/**
+ * Given the bundles array and the basePath (optional), returns the given
+ * bundles in the format of type `ThemeModel`.
+ *
+ * This is useful for defining the following in a dialog:
+ *
+ * ```tsx
+ * const CSS_BUNDLES: ThemeModel = getBundles(
+ *   [
+ *     "components/accordion",
+ *     "components/button",
+ *     "components/checkbox",
+ *     "components/combo-box",
+ *     "components/edit",
+ *     "components/tree-view",
+ *     "utils/form",
+ *     "utils/layout",
+ *   ],
+ *   "./assets/css/"
+ * );
+ *
+ * HTML/render/template:
+ *   <Host>
+ *     <ch-theme model={CSS_BUNDLES}></ch-theme>
+ *     ...
+ *   </Host>
+ * ```
+ */
+export const getBundles = (
+  bundles: MercuryBundleOptimized[] | MercuryBundleFull[],
+  basePath?: string
+): ThemeModel =>
+  basePath
+    ? bundles.map(bundle => getThemeModelItem(basePath, bundle))
+    : bundles;


### PR DESCRIPTION
Given the bundles array and the basePath (optional), returns the given bundles in the format of type `ThemeModel`.