### PR TITLE
`[mercury]` Allow to set `$globant-colors` in the config when customizing the paths

### DIFF
--- a/packages/mercury/README.md
+++ b/packages/mercury/README.md
@@ -87,6 +87,7 @@ npm i @genexus/mercury
         ```scss
         $icons-path: "assets/custom/path/icons/";
         $font-face-path: "assets/custom/path/fonts/";
+        $globant-colors: false;
         ```
 
     3.  Run the following command to transpile the bundles with the new path for the assets:

--- a/packages/mercury/src/bundles/scss/base/base.scss
+++ b/packages/mercury/src/bundles/scss/base/base.scss
@@ -6,7 +6,7 @@
 
   $light-theme: true,
   $dark-theme: true,
-  $globant-colors: true,
+  $globant-colors: $globant-colors,
 
   $font-face: true,
   $font-face-path: $font-face-path,

--- a/packages/mercury/src/config.scss
+++ b/packages/mercury/src/config.scss
@@ -3,3 +3,4 @@
 
 $icons-path: "./assets/icons/";
 $font-face-path: "./assets/fonts/";
+$globant-colors: false;


### PR DESCRIPTION
## Breaking changes
 - The `$globant-colors` must be added in the config.scss file when creating custom bundles for the CSS. [See the readme](https://github.com/genexuslabs/design-systems/tree/main/packages/mercury) for more information.
