### PR TITLE
[mercury] include dropdown bundle

### DIFF
--- a/packages/mercury/src/bundles.ts
+++ b/packages/mercury/src/bundles.ts
@@ -60,6 +60,7 @@ export const getThemeBundles = (basePath: string) =>
     getThemeModelItem(basePath, "components/combo-box"),
     getThemeModelItem(basePath, "components/flexible-layout"),
     getThemeModelItem(basePath, "components/dialog"),
+    getThemeModelItem(basePath, "components/dropdown"),
     getThemeModelItem(basePath, "components/icon"),
     getThemeModelItem(basePath, "components/edit"),
     getThemeModelItem(basePath, "components/layout-splitter"),


### PR DESCRIPTION
# Changes in this PR:

- Include missing bundle `components/dropdown`

## Breaking Changes
none