### PR TITLE
`[mercury][tabular-grid]` Stylize bar-resize-split and Inherit `.tabular-grid-cell` font-size on control items.

### DIFF
--- a/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
+++ b/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
@@ -69,7 +69,6 @@
   @include items-container-colors();
 
   --item__border-color--enabled: var(--mer-surface__elevation--01);
-  // @include tabular-grid-tokens();
   @include tabular-grid-row-tokens();
   @include tabular-grid-column-tokens();
   @include tabular-grid-cell-tokens();
@@ -83,6 +82,10 @@
 // - - - - - - - - - - - - - - - - - - - -
 %tabular-grid-column-set {
   border-block-end: var(--grid-cell__border);
+
+  &--hover {
+    --grid-bar-resize-split__bg-color: var(--mer-surface__elevation--03);
+  }
 }
 
 // - - - - - - - - - - - - - - - - - - - -
@@ -101,13 +104,20 @@
   @include control-font-weight-semi-bold();
   gap: var(--grid-common__gap);
   width: 100%;
+
+  &--hover {
+    --grid-bar-resize-split__bg-color: var(--mer-accent__primary);
+  }
 }
 
 %tabular-grid-column__bar-resize-split {
-  background-color: var(--mer-surface__elevation--01);
+  background-color: var(--grid-bar-resize-split__bg-color);
   inline-size: var(--grid-bar-resize-split__inline-size);
   &--hover {
-    background-color: var(--mer-accent__primary--hover);
+    --grid-bar-resize-split__bg-color: var(--mer-accent__primary--hover);
+  }
+  &--active {
+    --grid-bar-resize-split__bg-color: var(--mer-accent__primary--active);
   }
 }
 
@@ -499,6 +509,10 @@
 
   #{$tabular-grid-column-set} {
     @extend %tabular-grid-column-set;
+
+    &:hover {
+      @extend %tabular-grid-column-set--hover;
+    }
   }
 
   // - - - - - - - - - - - - - - - - - - - -
@@ -511,6 +525,9 @@
 
   #{$tabular-grid-column__bar-selector} {
     @extend %tabular-grid-column__bar;
+    &:hover {
+      @extend %tabular-grid-column__bar--hover;
+    }
   }
 
   #{$tabular-grid-column__bar-resize-split-selector} {

--- a/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
+++ b/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
@@ -206,6 +206,7 @@
 
   --control__font-size--regular: var(--grid-font-size);
   --control__font-size--small: var(--grid-font-size);
+  --item__font-size: var(--grid-font-size);
 
   border: 0; // WA
 

--- a/packages/mercury/src/components/tabular-grid/_tokens-grid.scss
+++ b/packages/mercury/src/components/tabular-grid/_tokens-grid.scss
@@ -1,3 +1,4 @@
 @mixin tabular-grid-tokens() {
   --grid__font-size: var(--mer-font__size--3xs);
+  --grid-bar-resize-split__bg-color: transparent;
 }


### PR DESCRIPTION
### Changes in this PR:

#### Tabular Grid

- The "bar-resize-split" part has been stylized with background colors. Hovering over the `ch-tabular-grid-columnset` changes the "bar-resize-split" background color, making it visible.

- Control items `font-size` now inherit the `.tabular-grid-cell` font-size. This is typically visible on the `.combo-box` control.