### PR TITLE
`[mercury][tabular-grid]` Make controls inherit font-styles

### DIFF
--- a/packages/mercury/src/components/chat/_chat-styles.scss
+++ b/packages/mercury/src/components/chat/_chat-styles.scss
@@ -125,7 +125,7 @@
     }
 
     @include input(
-      $selector: "&::part(send-input)",
+      $input-selector: "&::part(send-input)",
       $add--disabled: false,
       $add--placeholder: false,
       $add--error: false

--- a/packages/mercury/src/components/combo-box/_combo-box-styles.scss
+++ b/packages/mercury/src/components/combo-box/_combo-box-styles.scss
@@ -1,5 +1,6 @@
 @import "../../../../common/resets";
 @import "../../base/common";
+@import "../../config/tree-controls";
 
 %combo-box {
   --ch-combo-box-separation-y: var(--mer-spacing--3xs);
@@ -44,6 +45,7 @@
   &-group__header {
     @include item-colors-enabled();
     @include item-padding();
+    @extend %body-regular-m;
 
     &--expandable {
       @include item-colors-enabled();
@@ -69,11 +71,11 @@
   }
 
   &__item {
-    @extend %body-regular-m;
     @include item-colors-enabled();
     @include item-border();
     @include item-border-radius();
     @include item-padding();
+    @extend %body-regular-m;
 
     &--nested {
       padding-inline-start: calc(
@@ -114,7 +116,7 @@
 /// @param {Boolean} $add--placeholder [true] -
 /// @param {Boolean} $add--error [true] -
 @mixin combo-box(
-  $combo-box-selector: ".combo-box",
+  $combo-box-selector: $combo-box-selector,
   $combo-box--disabled-selector: ".combo-box[disabled]",
   $combo-box--error-selector: ".combo-box-error",
   $combo-box__placeholder-selector:

--- a/packages/mercury/src/components/input/_input-styles.scss
+++ b/packages/mercury/src/components/input/_input-styles.scss
@@ -1,3 +1,5 @@
+@import "../../config/tree-controls";
+
 %input {
   // ch-chameleon custom vars (do not edit their names)
   // --ch-edit-auto-fill-background-color: var(); not defined by design yet
@@ -24,19 +26,19 @@
 }
 
 /// @group Form
-/// @param {String} $selector [".input"] -
+/// @param {String} $input-selector [".input"] -
 /// @param {String} $error-selector [".input-error"] -
 /// @param {Boolean} $add--disabled [true] -
 /// @param {Boolean} $add--error [true] -
 @mixin input(
-  $selector: ".input",
+  $input-selector: $input-selector,
   $empty-placeholder-selector: ".input[part*='ch-edit--empty-value']",
   $error-selector: ".input-error",
   $add--disabled: true,
   $add--error: true,
   $add--placeholder: true
 ) {
-  #{$selector} {
+  #{$input-selector} {
     @extend %input;
 
     &:focus {

--- a/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
+++ b/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
@@ -70,13 +70,6 @@
 
   @extend %tabular-grid-font-size;
 
-  // make controls inherit tabular-grid font styles
-  @each $control-selector in $tree-controls {
-    #{$control-selector} {
-      @extend %tabular-grid-font-size;
-    }
-  }
-
   --indent: 16px;
   @include items-container-colors();
 
@@ -219,6 +212,13 @@
   // TODO: Check how controls font size's should be redefined inside tabular-grid cell, using the new font styles classes.
 
   border: 0; // WA
+
+  // make controls inherit tabular-grid font styles
+  @each $control-selector in $tree-controls {
+    > #{$control-selector} {
+      @extend %tabular-grid-font-size;
+    }
+  }
 
   &--focused {
     @include focus-outline();

--- a/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
+++ b/packages/mercury/src/components/tabular-grid/_tabular-grid-styles.scss
@@ -1,10 +1,15 @@
 @import "tokens-row";
 @import "tokens-column";
 @import "tokens-cell";
+@import "../../config/tree-controls";
 
 // - - - - - - - - - - - - - - - - - - - -
 //           general settings
 // - - - - - - - - - - - - - - - - - - - -
+
+%tabular-grid-font-size {
+  @extend %body-regular-s;
+}
 
 %tabular-grid__icon {
   &-size {
@@ -63,7 +68,14 @@
   --grid-common__gap: var(--mer-spacing--xs);
   max-block-size: 100%; // TODO: This reset must be placed in the control implementation. This property is a WA.
 
-  @extend %body-regular-s;
+  @extend %tabular-grid-font-size;
+
+  // make controls inherit tabular-grid font styles
+  @each $control-selector in $tree-controls {
+    #{$control-selector} {
+      @extend %tabular-grid-font-size;
+    }
+  }
 
   --indent: 16px;
   @include items-container-colors();
@@ -493,6 +505,7 @@
 
   #{$tabular-grid-selector} {
     @extend %tabular-grid;
+
     &:focus {
       outline: none;
     }

--- a/packages/mercury/src/config/_tree-controls.scss
+++ b/packages/mercury/src/config/_tree-controls.scss
@@ -1,0 +1,11 @@
+// In Mercury, some controls use different font styles than the tabular grid.
+// When these controls are inside a tabular grid, they should inherit its styles.
+// This ensures visual consistency across the interface. Add relevant selectors
+// below, then import this file where needed and apply the selector variable.
+
+// ie. for the combo-box: @mixin combo-box($combo-box-selector: $combo-box-selector, ...
+
+$combo-box-selector: ".combo-box";
+$input-selector: ".input";
+
+$tree-controls: ($combo-box-selector, $input-selector);


### PR DESCRIPTION
### Changes in this PR:

Make certain controls inherit the tabular grid’s font styles when placed as direct children of a cell, ensuring visual consistency across the interface.

Controls affected:
- Combo Box
- Input