### PR TITLE
Add support for multi-state icons in the `ch-action-menu-render` and bump minimum version for `@genexus/chameleon-controls-library`

### DIFF
--- a/packages/mercury/package.json
+++ b/packages/mercury/package.json
@@ -64,7 +64,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@atao60/fse-cli": "^0.1.9",
-    "@genexus/chameleon-controls-library": "6.0.0-next.55",
+    "@genexus/chameleon-controls-library": "~6.2.0",
     "@genexus/svg-sass-generator": "1.1.24",
     "@types/node": "~22.10.5",
     "chokidar": "^3.6.0",

--- a/packages/mercury/pnpm-lock.yaml
+++ b/packages/mercury/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.1.9
         version: 0.1.9
       '@genexus/chameleon-controls-library':
-        specifier: 6.0.0-next.55
-        version: 6.0.0-next.55(@stencil/core@4.19.2)
+        specifier: ~6.2.0
+        version: 6.2.0(@stencil/core@4.19.2)
       '@genexus/svg-sass-generator':
         specifier: 1.1.24
         version: 1.1.24(@types/node@22.10.7)
@@ -339,8 +339,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@genexus/chameleon-controls-library@6.0.0-next.55':
-    resolution: {integrity: sha512-mQ9fch9+wX0IkwogYPQVo38zgceISpN/j02bJbnmjfECfM6ReTeC56aBFLuPceoyW9Q6zB5dv39qky5iNIqv9A==}
+  '@genexus/chameleon-controls-library@6.2.0':
+    resolution: {integrity: sha512-pH+/USoocHtinMiBgcXZ50dsYMevolqGzPzqouQBhvsXifmsCUhemrRYWSSlgjvSPXI0cjzkQL1rKyIj7/1Jag==}
 
   '@genexus/markdown-parser@0.1.1':
     resolution: {integrity: sha512-mPWHAOekmjQ3C2V5N3GyUADW6gHuTRRj1ul5G2nxY+h09RwlNxVfYLUWCC4S20l0c6wQzHabgGf+nroyuZJjxw==}
@@ -1806,7 +1806,7 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
-  '@genexus/chameleon-controls-library@6.0.0-next.55(@stencil/core@4.19.2)':
+  '@genexus/chameleon-controls-library@6.2.0(@stencil/core@4.19.2)':
     dependencies:
       '@genexus/markdown-parser': 0.1.1
       html5-qrcode: 2.3.8

--- a/packages/mercury/src/assets-manager.ts
+++ b/packages/mercury/src/assets-manager.ts
@@ -1,4 +1,6 @@
 import type {
+  ActionMenuImagePathCallback,
+  ActionMenuItemActionableModel,
   ComboBoxImagePathCallback,
   GxImageMultiState,
   NavigationListItemModel,
@@ -203,6 +205,21 @@ export const getImagePathCallback = (
   return result;
 };
 
+export const getActionMenuImagePathCallback: ActionMenuImagePathCallback = (
+  item: ActionMenuItemActionableModel,
+  iconDirection: "start" | "end"
+) => {
+  if (
+    (!item.startImgSrc && iconDirection === "start") ||
+    (!item.endImgSrc && iconDirection === "end")
+  ) {
+    return undefined;
+  }
+  const imgSrc =
+    iconDirection === "start" ? item.startImgSrc! : item.endImgSrc!;
+  return getImagePathCallback(imgSrc);
+};
+
 export const getActionListImagePathCallback = (
   additionalItem: ActionListItemAdditionalBase
 ) =>
@@ -275,6 +292,7 @@ export const getComboBoxImagePathCallback: ComboBoxImagePathCallback = (
  */
 export const getImagePathCallbackDefinitions: RegistryGetImagePathCallback = {
   "ch-accordion-render": getImagePathCallback,
+  "ch-action-menu-render": getActionMenuImagePathCallback,
   "ch-action-list-render": getActionListImagePathCallback,
   "ch-combo-box-render": getComboBoxImagePathCallback,
   "ch-navigation-list-render": getNavigationListImagePathCallback,

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-server": "~19.0.5",
     "@angular/router": "~19.0.5",
     "@angular/ssr": "~19.0.6",
-    "@genexus/chameleon-controls-library": "~6.1.1",
+    "@genexus/chameleon-controls-library": "~6.2.0",
     "@genexus/mercury": "latest",
     "@genexus/unanimo": "latest",
     "express": "^4.21.2",

--- a/packages/showcase/src/app/chameleon-compatibility/mercury-compatibility-table.ts
+++ b/packages/showcase/src/app/chameleon-compatibility/mercury-compatibility-table.ts
@@ -2,6 +2,7 @@ export const mercuryCompatibilityTable: {
   version: string;
   chameleon: string;
 }[] = [
-  { version: "^0.10.0", chameleon: ">= 6.0.0-next.54" },
+  { version: "^0.15.0", chameleon: ">= 6.2.0" },
+  { version: "0.10.0 - 0.14.0", chameleon: "6.0.0-next.54 - 6.1.1" },
   { version: "~0.9.15", chameleon: "6.0.0-next.52 - 6.0.0-next.53" }
 ];


### PR DESCRIPTION
## Breaking changes

> [!IMPORTANT]  
> Use `@genexus/chameleon-controls-library` version >= `6.2.0`