### PR TITLE
`[mercury]` Bump minimum version for Chameleon

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build.mer.watch": "cd packages/mercury && yarn && yarn build.scss.watch",
     "build.un": "cd packages/unanimo && yarn && yarn build",
     "build.un.watch": "cd packages/unanimo && yarn && yarn build",
-    "start": "cd packages/showcase && yarn && yarn start"
+    "start": "cd packages/showcase && yarn && yarn start",
+    "start.watch": "cd packages/showcase && yarn && yarn start.watch"
   },
   "devDependencies": {
     "@types/node": "~22.13.4",

--- a/packages/mercury/package.json
+++ b/packages/mercury/package.json
@@ -67,7 +67,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@atao60/fse-cli": "^0.1.9",
-    "@genexus/chameleon-controls-library": "~6.2.0",
+    "@genexus/chameleon-controls-library": "~6.3.0",
     "@genexus/svg-sass-generator": "1.1.24",
     "@types/node": "~22.10.5",
     "chokidar": "^3.6.0",

--- a/packages/mercury/src/components/combo-box/_combo-box-styles.scss
+++ b/packages/mercury/src/components/combo-box/_combo-box-styles.scss
@@ -105,7 +105,7 @@
 /// @param {String} $combo-box-selector [".combo-box"] -
 /// @param {String} $combo-box--disabled-selector [".combo-box[disabled]"] -
 /// @param {String} $combo-box--error-selector [".combo-box-error"] -
-/// @param {String} $combo-box__placeholder-selector [".combo-box[part='ch-combo-box-render--empty-value']"] -
+/// @param {String} $combo-box__placeholder-selector [".combo-box[part='ch-combo-box-render--placeholder']"] -
 /// @param {String} $window-selector [".combo-box::part(window)"] -
 /// @param {String} $group-selector [".combo-box::part(group)"] -
 /// @param {String} $group__content-selector [".combo-box::part(group__content)"] -
@@ -124,7 +124,7 @@
   $combo-box--disabled-selector: ".combo-box[disabled]",
   $combo-box--error-selector: ".combo-box-error",
   $combo-box__placeholder-selector:
-    ".combo-box[part='ch-combo-box-render--empty-value']",
+    ".combo-box[part='ch-combo-box-render--placeholder']",
   $window-selector: ".combo-box::part(window)",
   $group-selector: ".combo-box::part(group)",
   $group__content-selector: ".combo-box::part(group__content)",

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-server": "~19.0.5",
     "@angular/router": "~19.0.5",
     "@angular/ssr": "~19.0.6",
-    "@genexus/chameleon-controls-library": "~6.2.0",
+    "@genexus/chameleon-controls-library": "~6.3.0",
     "@genexus/mercury": "latest",
     "@genexus/unanimo": "latest",
     "express": "^4.21.2",

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "yarn build.scss && ng serve -o --port 0",
+    "start.watch": "ng serve -o --port 0",
     "build": "yarn build.scss && ng build",
     "build.scss": "mercury -i=/assets/icons/ -f=/assets/fonts/ --outDir=.mercury/ --avoid-hash=base/base",
     "watch": "ng build --watch --configuration development",

--- a/packages/showcase/src/app/chameleon-compatibility/mercury-compatibility-table.ts
+++ b/packages/showcase/src/app/chameleon-compatibility/mercury-compatibility-table.ts
@@ -2,7 +2,8 @@ export const mercuryCompatibilityTable: {
   version: string;
   chameleon: string;
 }[] = [
-  { version: "^0.15.0", chameleon: ">= 6.2.0" },
+  { version: "^0.16.0", chameleon: "^6.3.0" },
+  { version: "0.15.0 - 0.15.1", chameleon: "6.2.0 - 6.2.1" },
   { version: "0.10.0 - 0.14.0", chameleon: "6.0.0-next.54 - 6.1.1" },
   { version: "~0.9.15", chameleon: "6.0.0-next.52 - 6.0.0-next.53" }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
     qr-creator "^1.0.0"
     stencil-click-outside "^1.8.0"
 
-"@genexus/chameleon-controls-library@~6.2.0":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@genexus/chameleon-controls-library/-/chameleon-controls-library-6.2.1.tgz#8d7eaab31ffc73f076a51619ed660af52eb1d400"
-  integrity sha512-Sh3KZkXMoS6u90NoALUy0+Fro26TSS+wjvPOXvvjmsYsKPMMonDl4c0dYMz8NfG3SzKXJHOXFMVe0vVYYjSfSA==
+"@genexus/chameleon-controls-library@~6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@genexus/chameleon-controls-library/-/chameleon-controls-library-6.3.0.tgz#106f830093694389438346b2988773a7d71ed6ed"
+  integrity sha512-Ulm1JO4CZR62PfGtQnnSWUkerwdeFaVz4RRRBLs9UACbebOMhtQcD6xhWogXfNb7vSjHnW7CA+qWUJI2KrQPlg==
   dependencies:
     "@genexus/markdown-parser" "~0.1.1"
     html5-qrcode "^2.3.8"


### PR DESCRIPTION
Mercury now requires `chameleon-controls-library >= 6.3.0`